### PR TITLE
updated addTarget selectors to the Swift 2.2 syntax style of #selector()

### DIFF
--- a/SwiftPages/RAReorderableLayout.swift
+++ b/SwiftPages/RAReorderableLayout.swift
@@ -213,7 +213,7 @@ public class RAReorderableLayout: UICollectionViewFlowLayout {
     private func setUpDisplayLink() {
         guard displayLink == nil else { return }
         
-        displayLink = CADisplayLink(target: self, selector: "continuousScroll")
+        displayLink = CADisplayLink(target: self, selector: #selector(RAReorderableLayout.continuousScroll))
         displayLink!.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
     
@@ -359,8 +359,8 @@ public class RAReorderableLayout: UICollectionViewFlowLayout {
     private func setUpGestureRecognizers() {
         guard nil != collectionView else { return }
         
-        longPress = UILongPressGestureRecognizer(target: self, action: "handleLongPress:")
-        panGesture = UIPanGestureRecognizer(target: self, action: "handlePanGesture:")
+        longPress = UILongPressGestureRecognizer(target: self, action: #selector(RAReorderableLayout.handleLongPress(_:)))
+        panGesture = UIPanGestureRecognizer(target: self, action: #selector(RAReorderableLayout.handlePanGesture(_:)))
         longPress?.delegate = self
         panGesture?.delegate = self
         panGesture?.maximumNumberOfTouches = 1

--- a/SwiftPages/SwiftPages.swift
+++ b/SwiftPages/SwiftPages.swift
@@ -76,9 +76,9 @@ public class SwiftPages: UIView {
             
             // Set the notifications for an orientation change & BG mode
             let defaultNotificationCenter = NSNotificationCenter.defaultCenter()
-            defaultNotificationCenter.addObserver(self, selector: Selector("applicationWillEnterBackground"), name: UIApplicationWillResignActiveNotification, object: nil)
-            defaultNotificationCenter.addObserver(self, selector: Selector("orientationWillChange"), name: UIApplicationWillChangeStatusBarOrientationNotification, object: nil)
-            defaultNotificationCenter.addObserver(self, selector: Selector("orientationDidChange"), name: UIDeviceOrientationDidChangeNotification, object: nil)
+            defaultNotificationCenter.addObserver(self, selector: #selector(SwiftPages.applicationWillEnterBackground), name: UIApplicationWillResignActiveNotification, object: nil)
+            defaultNotificationCenter.addObserver(self, selector: #selector(SwiftPages.orientationWillChange), name: UIApplicationWillChangeStatusBarOrientationNotification, object: nil)
+            defaultNotificationCenter.addObserver(self, selector: #selector(SwiftPages.orientationDidChange), name: UIDeviceOrientationDidChangeNotification, object: nil)
             
             // Set the containerView, every item is constructed relative to this view
             self.containerView = UIView(frame: CGRect(x: self.xOrigin, y: self.yOrigin, width: pagesContainerWidth, height: pagesContainerHeight))
@@ -152,7 +152,7 @@ public class SwiftPages: UIView {
                     barButton.imageView?.contentMode = .ScaleAspectFit
                     barButton.setImage(image, forState: .Normal)
                     barButton.tag = index
-                    barButton.addTarget(self, action: "barButtonAction:", forControlEvents: .TouchUpInside)
+                    barButton.addTarget(self, action: #selector(SwiftPages.barButtonAction(_:)), forControlEvents: .TouchUpInside)
                     self.topBar.addSubview(barButton)
                     self.barButtons.append(barButton)
                     
@@ -170,7 +170,7 @@ public class SwiftPages: UIView {
                     barButton.setTitle(title, forState: .Normal)
                     barButton.setTitleColor(self.buttonsTextColor, forState: .Normal)
                     barButton.tag = index
-                    barButton.addTarget(self, action: "barButtonAction:", forControlEvents: .TouchUpInside)
+                    barButton.addTarget(self, action: #selector(SwiftPages.barButtonAction(_:)), forControlEvents: .TouchUpInside)
                     self.topBar.addSubview(barButton)
                     self.barButtons.append(barButton)
                     


### PR DESCRIPTION
Swift 2.2 update built type safety into our addTarget selector calls and adds a #selector() requirement to the method. This allows for checks on targeted methods pre runtime and saves on the runtime errors associated.
